### PR TITLE
Use circleci/node:14 for CI testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:14
 
     working_directory: ~/repo
 


### PR DESCRIPTION
I added a tiny change to use a newer version of Node.js on CI build :)