### PR TITLE
Chore/Remove unused `cross-env`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "babel-eslint": "^8.0.2",
     "chai": "^4.1.2",
     "chokidar-cli": "^2.1.0",
-    "cross-env": "^5.1.1",
     "eslint": "^4.11.0",
     "eslint-plugin-mocha": "^4.11.0",
     "mocha": "^8.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,13 +1611,6 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cross-env@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.1.tgz#b6d8ab97f304c0f71dae7277b75fe424c08dfa74"
-  dependencies:
-    cross-spawn "^5.1.0"
-    is-windows "^1.0.0"
-
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2742,7 +2735,7 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.1"
 
-is-windows@^1.0.0, is-windows@^1.0.2:
+is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==


### PR DESCRIPTION
@RobertMaciejewski @NEWROPE/dev 

When investigating https://github.com/NEWROPE/scnnr-js/pull/28 I didn't find any use of `cross-env` in the codebase. See https://github.com/kentcdodds/cross-env#usage
=> I removed the unused (deprecated https://github.com/kentcdodds/cross-env#cross-env- package)

Please review.