### PR TITLE
Chore/Prepare release for version 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2021-06-08
+### Security
+- Upgrade various dependencies.
+
 ## [1.0.1] - 2019-06-11
 ### Security
 - Upgrade dependencies to fix vulnerabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.0.2] - 2021-06-08
 ### Security
-- Upgrade various dependencies.
+- Upgrade various dependencies for development.
+- Upgrade Axios to 0.21.1
+  - https://github.com/NEWROPE/scnnr-js/pull/40
+  - https://github.com/NEWROPE/scnnr-js/pull/42
+  - https://github.com/NEWROPE/scnnr-js/pull/47
 
 ## [1.0.1] - 2019-06-11
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scnnr",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Official #CBK scnnr client library for JavaScript",
   "main": "dist/scnnr.bundle.umd.js",
   "module": "dist/scnnr.esm.js",


### PR DESCRIPTION
@hiroara @NEWROPE/dev 

Similar to https://github.com/NEWROPE/scnnr-js/pull/18
Current changes: https://github.com/NEWROPE/scnnr-js/compare/v1.0.1...master

Maybe we discussed making a new release after dealing with all open Dependabot PRs. So I went ahead and prepared it.

Please review.