### PR TITLE
Chore/Bump version to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2021-09-14
+### Security
+- Upgrade Axios to 0.21.4
+  - https://github.com/NEWROPE/scnnr-js/pull/57
+
 ## [1.0.2] - 2021-06-08
 ### Security
 - Upgrade various dependencies for development.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scnnr",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Official #CBK scnnr client library for JavaScript",
   "main": "dist/scnnr.bundle.umd.js",
   "module": "dist/scnnr.esm.js",


### PR DESCRIPTION
@iusztin @NEWROPE/dev 

Based on https://github.com/NEWROPE/scnnr-js/pull/53
Diff: https://github.com/NEWROPE/scnnr-js/compare/v1.0.2...master

Prepared release of 1.0.3

Please check 🙏 